### PR TITLE
Remove unused .vercel gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-.vercel


### PR DESCRIPTION
Last remaining Vercel reference in the repo now that the project has moved to Cloudflare Pages.